### PR TITLE
camera_cards: changes to variable naming

### DIFF
--- a/camera_cards
+++ b/camera_cards
@@ -223,8 +223,7 @@ if [[ "${AIP}" == "YES" ]] ; then
     # concatenate video files in the order they are printed in $TEMP_CONCATLIST; map metadata from the first video file (in sequence) onto the concatenated file
     ffmpeg -f concat -safe 0 -i "${TEMP_CONCATLIST}" -i "${FIRST_FILE}" -map 0 -map_metadata 1 -c copy "${CONCATENATED_VIDEO_FILE}"
     # calculate md5 for each stream in the file
-    CONCATENATED_VIDEO_FILE_BASENAME="$(basename ${CONCATENATED_VIDEO_FILE})"
-    STREAMHASH="${METADATA_OUTPUT_DIR}/${CONCATENATED_VIDEO_FILE_BASENAME%.*}_streamhash.md5"
+    STREAMHASH="${METADATA_OUTPUT_DIR}/$(basename ${CONCATENATED_VIDEO_FILE%.*})_streamhash.md5"
     ffmpeg -i "${CONCATENATED_VIDEO_FILE}" -map 0 -f streamhash -hash md5 "${STREAMHASH}"
     # tests for video file existing
     FFMPEG_EXIT_CODE=$(echo $?)
@@ -256,22 +255,21 @@ if [[ "${AIP}" == "YES" ]] ; then
         if [[ "${VIDEO_DURATION}" -ne "${AUDIO_DURATION}" ]] ; then
             _report -r "Audio and video files are not the same length! Review output for sync. (Video duration = ${VIDEO_DURATION}, audio duration = ${AUDIO_DURATION})"
         fi
-        # rename concatenated video file to avoid collision
-        NEW_CONCATENATED_VIDEO_FILE="$(echo "${CONCATENATED_VIDEO_FILE}" | sed s/concatenated/concatenated_video/)"
-        mv "${CONCATENATED_VIDEO_FILE}" "${NEW_CONCATENATED_VIDEO_FILE}"
-        CONCATENATED_FILE="${AIPDIR}/objects/${MEDIAID}_concatenated.${FIRST_FILE#*.}"
-        ffmpeg -i "${NEW_CONCATENATED_VIDEO_FILE}" -i "${CONCATENATED_AUDIO_FILE}" -c:v copy -c:a copy "${CONCATENATED_FILE}"
-        _writelog "JOINED FILE (AUDIO AND VIDEO)" "${CONCATENATED_FILE}"
+        # rename concatenated video file to avoid collision with audio file
+        RENAMED_CONCATENATED_VIDEO_FILE="$(echo "${CONCATENATED_VIDEO_FILE}" | sed s/concatenated/concatenated_video/)"
+        mv "${CONCATENATED_VIDEO_FILE}" "${RENAMED_CONCATENATED_VIDEO_FILE}"
+        CONCATENATED_FILE_MERGED="${AIPDIR}/objects/${MEDIAID}_concatenated.${FIRST_FILE#*.}"
+        ffmpeg -i "${RENAMED_CONCATENATED_VIDEO_FILE}" -i "${CONCATENATED_AUDIO_FILE}" -c:v copy -c:a copy "${CONCATENATED_FILE_MERGED}"
+        _writelog "JOINED FILE (AUDIO AND VIDEO)" "${CONCATENATED_FILE_MERGED}"
         _writelog -t "Audio + video joining process ended"
     fi
     
     # generate md5 of concatenated file
-    if [[ -f "${CONCATENATED_FILE}" ]] ; then
-        CONCATENATED_FILE_BASENAME="$(basename ${CONCATENATED_FILE})"
-        CONCATENATED_MD5_OUTPUT="${METADATA_OUTPUT_DIR}/${CONCATENATED_FILE_BASENAME%.*}.md5"
-        md5sum "${CONCATENATED_FILE}" | awk '{print $1}' > "${CONCATENATED_MD5_OUTPUT}"
+    if [[ -f "${CONCATENATED_FILE_MERGED}" ]] ; then
+        CONCATENATED_MD5_OUTPUT="${METADATA_OUTPUT_DIR}/$(basename ${CONCATENATED_FILE_MERGED%.*}).md5"
+        md5sum "${CONCATENATED_FILE_MERGED}" | awk '{print $1}' > "${CONCATENATED_MD5_OUTPUT}"
     else
-        CONCATENATED_MD5_OUTPUT="${METADATA_OUTPUT_DIR}/${CONCATENATED_VIDEO_FILE%.*}.md5"
+        CONCATENATED_MD5_OUTPUT="${METADATA_OUTPUT_DIR}/$(basename ${CONCATENATED_VIDEO_FILE%.*}).md5"
         md5sum "${CONCATENATED_VIDEO_FILE}" | awk '{print $1}' > "${CONCATENATED_MD5_OUTPUT}"
     fi
     
@@ -360,7 +358,7 @@ else
 fi
 if [[ -s "${CONCATENATED_AUDIO_FILE}" ]] ; then
     if [[ "${VIDEO_DURATION}" -ne "${AUDIO_DURATION}" ]] ; then
-    _report -r "Concatenated audio and video files were not the same length - review final merged file for sync at ${CONCATENATED_FILE} (video duration = ${VIDEO_DURATION}, audio duration = ${AUDIO_DURATION})"
+    _report -r "Concatenated audio and video files were not the same length - review final merged file for sync at ${CONCATENATED_FILE_MERGED} (video duration = ${VIDEO_DURATION}, audio duration = ${AUDIO_DURATION})"
     _writelog "POSSIBLE_ERROR_REVIEW" "Concatenated audio and video files were not the same length"
     else
         _report -g "Concatenated audio and video process looks ok"


### PR DESCRIPTION
-consolidating invocation of "basename" command
-changing variable names to be clearer within the script (NEW_CONCATENATED_VIDEO_FILE -> RENAMED_CONCATENATED_VIDEO_FILE, CONCATENATED_FILE -> CONCATENATED_FILE_MERGED)

Hopefully addresses .md5 filenaming issues raised by Chialin in https://github.com/NMAAHC/nmaahcmm/issues/29#issuecomment-1061773896