### PR TITLE
md5 and metadata updates

### DIFF
--- a/camera_cards
+++ b/camera_cards
@@ -58,9 +58,9 @@ _generate_metadata(){
     tree -DaNs --du --timefmt "%Y-%m-%dT%H:%M:%SZ" "${CAMERA_CARD_DIR}" > "${TREE}"
     # create mediainfo, exiftool, ffprobe reports
     while read -r FILE ; do
-        MEDIAINFO_OUTPUT="${METADATA_OUTPUT_DIR}/$(basename ${FILE})_mediainfo.txt"
-        EXIFTOOL_OUTPUT="${METADATA_OUTPUT_DIR}/$(basename ${FILE})_exiftool.txt"
-        FFPROBE_OUTPUT="${METADATA_OUTPUT_DIR}/$(basename ${FILE})_ffprobe.xml"
+        MEDIAINFO_OUTPUT="${METADATA_OUTPUT_DIR}/$(basename "${FILE}")_mediainfo.txt"
+        EXIFTOOL_OUTPUT="${METADATA_OUTPUT_DIR}/$(basename "${FILE}")_exiftool.txt"
+        FFPROBE_OUTPUT="${METADATA_OUTPUT_DIR}/$(basename "${FILE}")_ffprobe.xml"
         mediaconch -mi -ft "${FILE}" >> "${MEDIAINFO_OUTPUT}"
         exiftool "${FILE}" >> "${EXIFTOOL_OUTPUT}"
         ffprobe 2> /dev/null "${FILE}" -show_format -show_streams -show_data -show_error -show_versions -show_chapters -noprivate -of xml="q=1:x=1" > "${FFPROBE_OUTPUT}"
@@ -223,7 +223,7 @@ if [[ "${AIP}" == "YES" ]] ; then
     # concatenate video files in the order they are printed in $TEMP_CONCATLIST; map metadata from the first video file (in sequence) onto the concatenated file
     ffmpeg -f concat -safe 0 -i "${TEMP_CONCATLIST}" -i "${FIRST_FILE}" -map 0 -map_metadata 1 -c copy "${CONCATENATED_VIDEO_FILE}"
     # calculate md5 for each stream in the file
-    STREAMHASH="${METADATA_OUTPUT_DIR}/$(basename ${CONCATENATED_VIDEO_FILE%.*})_streamhash.md5"
+    STREAMHASH="${METADATA_OUTPUT_DIR}/$(basename "${CONCATENATED_VIDEO_FILE%.*}")_streamhash.md5"
     ffmpeg -i "${CONCATENATED_VIDEO_FILE}" -map 0 -f streamhash -hash md5 "${STREAMHASH}"
     # tests for video file existing
     FFMPEG_EXIT_CODE=$(echo $?)
@@ -266,10 +266,10 @@ if [[ "${AIP}" == "YES" ]] ; then
     
     # generate md5 of concatenated file
     if [[ -f "${CONCATENATED_FILE_MERGED}" ]] ; then
-        CONCATENATED_MD5_OUTPUT="${METADATA_OUTPUT_DIR}/$(basename ${CONCATENATED_FILE_MERGED%.*}).md5"
+        CONCATENATED_MD5_OUTPUT="${METADATA_OUTPUT_DIR}/$(basename "${CONCATENATED_FILE_MERGED%.*}").md5"
         md5sum "${CONCATENATED_FILE_MERGED}" > "${CONCATENATED_MD5_OUTPUT}"
     else
-        CONCATENATED_MD5_OUTPUT="${METADATA_OUTPUT_DIR}/$(basename ${CONCATENATED_VIDEO_FILE%.*}).md5"
+        CONCATENATED_MD5_OUTPUT="${METADATA_OUTPUT_DIR}/$(basename "${CONCATENATED_VIDEO_FILE%.*}").md5"
         md5sum "${CONCATENATED_VIDEO_FILE}" > "${CONCATENATED_MD5_OUTPUT}"
     fi
     

--- a/camera_cards
+++ b/camera_cards
@@ -267,10 +267,10 @@ if [[ "${AIP}" == "YES" ]] ; then
     # generate md5 of concatenated file
     if [[ -f "${CONCATENATED_FILE_MERGED}" ]] ; then
         CONCATENATED_MD5_OUTPUT="${METADATA_OUTPUT_DIR}/$(basename ${CONCATENATED_FILE_MERGED%.*}).md5"
-        md5sum "${CONCATENATED_FILE_MERGED}" | awk '{print $1}' > "${CONCATENATED_MD5_OUTPUT}"
+        md5sum "${CONCATENATED_FILE_MERGED}" > "${CONCATENATED_MD5_OUTPUT}"
     else
         CONCATENATED_MD5_OUTPUT="${METADATA_OUTPUT_DIR}/$(basename ${CONCATENATED_VIDEO_FILE%.*}).md5"
-        md5sum "${CONCATENATED_VIDEO_FILE}" | awk '{print $1}' > "${CONCATENATED_MD5_OUTPUT}"
+        md5sum "${CONCATENATED_VIDEO_FILE}" > "${CONCATENATED_MD5_OUTPUT}"
     fi
     
     if [[ "${CAMERA_CARD_TYPE}" == "GENERAL" ]] ; then
@@ -339,7 +339,7 @@ if [[ "${TAR}" == "YES" ]] ; then
     
     ## generate checksum for tar archive
     TAR_MD5_OUTPUT="${METADATA_OUTPUT_DIR}/${MEDIAID}.md5"
-    md5sum "${MEDIAID}.tar.gz" | awk '{print $1}' > "${TAR_MD5_OUTPUT}"
+    md5sum "${MEDIAID}.tar.gz" > "${TAR_MD5_OUTPUT}"
 fi
 
 # error reporting

--- a/camera_cards
+++ b/camera_cards
@@ -312,9 +312,9 @@ fi
 
 ### procedure for packaging files into compressed tars
 if [[ "${TAR}" == "YES" ]] ; then
-    if [[ "${AIP}" == "YES" ]] ; then AIPDIR="${AIP_DESTINATION}/${MEDIAID}_TAR" ; fi # if both AIP and TAR will be created, differentiate output packages
+    if [[ "${AIP}" == "YES" ]] ; then AIPDIR_TAR="${AIP_DESTINATION}/${MEDIAID}_TAR" ; fi # if both AIP and TAR will be created, differentiate output packages
     
-    mkdir -p "${AIPDIR}/objects" "${AIPDIR}/metadata"
+    mkdir -p "${AIPDIR_TAR}/objects" "${AIPDIR_TAR}/metadata"
     
     ## create metadata reports for original package and audiovisual files
     # identify all files with a video or audio track; sort video and audio files into separate lists, and all other files into a list of metadata files
@@ -325,7 +325,7 @@ if [[ "${TAR}" == "YES" ]] ; then
         fi
     done <"${TEMP_ALLFILES}"
     # generate metadata reports
-    METADATA_OUTPUT_DIR="${AIPDIR}/metadata"
+    METADATA_OUTPUT_DIR="${AIPDIR_TAR}/metadata/reports"
     METADATA_FILELIST="${TEMP_AVLIST}"
     _generate_metadata
     
@@ -333,7 +333,7 @@ if [[ "${TAR}" == "YES" ]] ; then
     echo
     _report -g "Creating tar archive..."
     _writelog -t "Tar archive process process started"
-    tar -czvf "${AIPDIR}/objects/${MEDIAID}.tar.gz" -C "${CAMERA_CARD_DIR}" .
+    tar -czvf "${AIPDIR_TAR}/objects/${MEDIAID}.tar.gz" -C "${CAMERA_CARD_DIR}" .
     _writelog "TAR ARCHIVE" "${MEDIAID}.tar.gz"
     _writelog -t "Tar archive process process finished"
     

--- a/camera_cards
+++ b/camera_cards
@@ -297,7 +297,7 @@ if [[ "${AIP}" == "YES" ]] ; then
     if [[ "${CAMERA_CARD_TYPE}" == "AVCHD" ]] ; then
         find "${CAMERA_CARD_DIR}" -type f -iname "*.cpi" -exec rsync -avh {} "${AIPDIR}/metadata/original_camera_files/" \;
     elif [[ "${CAMERA_CARD_TYPE}" == "MXF" ]] || [[ "${CAMERA_CARD_TYPE}" == "XDCAMEX" ]] ; then
-        find "${CAMERA_CARD_DIR}" -type f \( -iname "*.xml" -o -iname "*.xmp" -o -iname "INDEX.MIF" \) -exec rsync -avh {} "${AIPDIR}/metadata/original_camera_files/" \;
+        find "${CAMERA_CARD_DIR}" -type f \( -iname "*.xml" -o -iname "*.xmp" -o -iname "INDEX.MIF" -o -iname "*.cpf" \) -exec rsync -avh {} "${AIPDIR}/metadata/original_camera_files/" \;
     elif [[ "${CAMERA_CARD_TYPE}" == "XAVC" ]] ; then
         find "${CAMERA_CARD_DIR}" -type f \( -iname "*.xml" -o -iname "*.bim" \) -exec rsync -avh {} "${AIPDIR}/metadata/original_camera_files/" \;
     elif [[ "${CAMERA_CARD_TYPE}" == "P2" ]] ; then


### PR DESCRIPTION
- keep the CPF file (along with index.mif file) for editing use cases
- plain md5sum output (not stripping the filename)
- fix issue where .md5 files took part of the filepath in their names