### PR TITLE
makeframemd5 - remove framemd5 dependency, fixes #41

### DIFF
--- a/makeframemd5
+++ b/makeframemd5
@@ -4,7 +4,7 @@ SCRIPT_PATH="${0%/*}"
 . "${SCRIPT_PATH}/nmaahcmmfunctions"
 [[ -f "${SCRIPT_PATH}/nmaahcmmfunctions" ]] || { echo "Missing '${SCRIPT_PATH}/nmaahcmmfunctions'. Exiting." ; exit 1 ;};
 _initialize_make # safe script termination process defined in nmaahcmmfunctions
-DEPENDENCIES=(ffmpeg framemd5) # list dependencies required by script
+DEPENDENCIES=(ffmpeg) # list dependencies required by script
 _check_dependencies "${DEPENDENCIES[@]}" # defined in nmaahcmmfunctions
 
 ### USAGE


### PR DESCRIPTION
Looks like `framemd5` was a dependency which doesn't seem correct. I removed the dependency and the script created a framemd5 file as expected.