### PR TITLE
multiline metadata refactor

### DIFF
--- a/mkvnote
+++ b/mkvnote
@@ -347,11 +347,13 @@ fi
 EXISTING_TAGS="$(_maketemp).txt"
 XML_DRAFT="$(_maketemp).xml"
 
-mkvextract tags "${INPUT_FILE}" | xmlstarlet sel -t -m "/Tags/Tag[Targets='' or not(Targets) or (Targets/TargetTypeValue='50' and not(Targets/TrackUID))]/Simple" -v "Name" -o "=" -v "String" -n >> "${EXISTING_TAGS}"
+mkvextract tags "${INPUT_FILE}" | xmlstarlet sel -t -m "/Tags/Tag[Targets='' or not(Targets) or (Targets/TargetTypeValue='50' and not(Targets/TrackUID))]/Simple" -v "Name" -n >> "${EXISTING_TAGS}"
 
-while IFS="=" read -r EXISTING_KEY EXISTING_VALUE ; do
+while read EXISTING_KEY ; do
     DIALOG_LIST+="${EXISTING_KEY} "
     if [[ ! ${SELECTED_TAG_SET[*]} =~ "\"${EXISTING_KEY}\"" ]] ; then
+        TEMP_DIALOG_VALUE="$(_maketemp).txt"
+        mkvextract tags "${INPUT_FILE}" | xmlstarlet sel -t -m "/Tags/Tag[Targets='' or not(Targets) or (Targets/TargetTypeValue='50' and not(Targets/TrackUID))]/Simple[Name='${EXISTING_KEY}']" -v "String" > "${TEMP_DIALOG_VALUE}"
         DIALOG_LIST_EMBEDDED+=("    <hbox>
         <vbox width-request=\"200\">
             <text xalign=\"0\">
@@ -359,10 +361,11 @@ while IFS="=" read -r EXISTING_KEY EXISTING_VALUE ; do
             </text>
         </vbox>
         <vbox width-request=\"800\">
-            <entry width=\"700\" space-fill=\"false\">
-                <default>${EXISTING_VALUE}</default>
+            <edit width=\"700\" space-fill=\"false\">
                 <variable>${EXISTING_KEY}</variable>
-            </entry>
+                <input file>${TEMP_DIALOG_VALUE}</input>
+                <action signal=\"show\">refresh:${EXISTING_KEY}</action>
+            </edit>
         </vbox>
     </hbox>
 ")
@@ -446,13 +449,13 @@ cat << EOF > "${DIALOG_FORM}"
       </vbox>
 </window>
 EOF
-
+echo "${DIALOG_FORM}" > /tmp/hi ; mate /tmp/hi
 DIALOG_RESULT="$(export MAIN_DIALOG="$(cat "${DIALOG_FORM}")" ; gtkdialog --center --program MAIN_DIALOG)"
-
+echo "${DIALOG_RESULT}"
 EXIT_STATUS="$(echo "${DIALOG_RESULT}" | grep "^EXIT=" | cut -d= -f2- | sed 's/^"//g;s/"$//g')"
 
 if [[ "${EXIT_STATUS}" == "Cancel" ]] ; then
-    echo "Nevermind then o_o"
+    echo "Nevermind then o_o ${EXISTING_TAGS}"
     exit
 elif [[ "${EXIT_STATUS}" == "Tag-On!" ]] ; then
     # Starts the XML draft for MKV metadata embedding with a root Tags element.
@@ -460,15 +463,34 @@ elif [[ "${EXIT_STATUS}" == "Tag-On!" ]] ; then
 
     # Reads the edited tag template line by line, extracting tag names and values entered by the user.
     # Only lines that conform to the expected format (tag_name=[tag_value]) are processed.
+    READ_MULTILINE=0
     while read TAG_LINE ; do
-        # Extracts the tag name by splitting the line at the colon and taking the first part.
-        TAG_NAME="$(echo "${TAG_LINE}" | cut -d "=" -f1)"
-        # Extracts the tag value by splitting the line at the colon and taking the second part.
-        TAG_VALUE="$(echo "${TAG_LINE}" | cut -d "=" -f2- | sed 's/^"//g;s/"$//g')"
+        if [[ "${READ_MULTILINE}" = "0" ]] ; then
+            # Extracts the tag name by splitting the line at the colon and taking the first part.
+            TAG_NAME="$(echo "${TAG_LINE}" | cut -d "=" -f1)"
+            if [[ "$(echo "${TAG_LINE}" | grep -c "^[^=]*=\".*\"$")" != "0" ]] ; then
+                # Extracts the tag value by splitting the line at the colon and taking the second part.
+                TAG_VALUE="$(echo "${TAG_LINE}" | cut -d "=" -f2- | sed 's/^"//g;s/"$//g')"
+            else
+                # Extracts the tag value by splitting the line at the colon and taking the second part.
+                TAG_VALUE="$(echo "${TAG_LINE}" | cut -d "=" -f2- | sed 's/^"//g')"
+                READ_MULTILINE="1"
+                continue
+            fi
+        else
+            if [[ "$(echo "${TAG_LINE}" | grep -c "\"$")" != "0" ]] ; then
+                TAG_VALUE+="\n$(echo "${TAG_LINE}" | sed 's/"$//g')"
+                READ_MULTILINE="0"
+            else
+                TAG_VALUE+="\n${TAG_LINE}"
+                continue
+            fi
+        fi
+        echo -e "${TAG_NAME} ... ${TAG_VALUE}"
         # If the tag value is not empty, the tag is added to the XML draft for embedding.
         # The xmlstarlet tool is used to edit the XML structure, ensuring each tag is uniquely added.
         if [[ -n "${TAG_VALUE// /}" ]] ; then
-            xml ed --omit-decl --inplace --subnode "/Tags/Tag[not(Simple/Name='${TAG_NAME}')]" --type elem -n "Simple" --subnode "/Tags/Tag/Simple[not(Name)]" --type elem -n "Name" -v "${TAG_NAME}" --subnode "/Tags/Tag/Simple[not(String)]" --type elem -n "String" -v "${TAG_VALUE}" "${XML_DRAFT}"
+            xml ed --omit-decl --inplace --subnode "/Tags/Tag[not(Simple/Name='${TAG_NAME}')]" --type elem -n "Simple" --subnode "/Tags/Tag/Simple[not(Name)]" --type elem -n "Name" -v "${TAG_NAME}" --subnode "/Tags/Tag/Simple[not(String)]" --type elem -n "String" -v "$(echo -e "${TAG_VALUE}")" "${XML_DRAFT}"
         fi
     done < <(echo "${DIALOG_RESULT}" | grep -v "^EXIT=")
 

--- a/mkvnote
+++ b/mkvnote
@@ -294,22 +294,6 @@ if [[ "${EXTENSION}" == "csv" ]] ; then
     exit
 
     DIALOG_FORM="$(_maketemp).xml"
-
-    cat << EOF> "${DIALOG_FORM}"
-{
-  "title" : "NMAAHC MKV Tagging for ${INPUT_FILE_NAME}",
-  "ontop" : 1,
-  "moveable" : 1,
-  "width" : "75%",
-  "height" : "75%",
-  "background" : "color=#800080",
-  "message" : "These tags semantically are intended to describe the file as a whole and not intended to specifically refer to a particular track or attachment or other sort of piece of the file. Empty tags will be ignored. If you edit exisitng tags here they will be overwritten when saved.\n\n${CSV_TABLE}",
-  "infobox" : "### Aditional Info\n\n#### To upload your key:value tag data in .csv \n - choose a .csv file to upload \n - choose a directory where the .mkv you wish to tag are \n - click the 'File Style' button on the bottom left \n - be cool \n#### To tag file via this gui \n - click the 'Tag-On' button on the bottom left \n - follow the instructions",
-    "button1text" : "Tag-On!!",
-    "button2text" : "Cancel"
-}
-EOF
-
     DIALOG_RESULT="$(dialog --jsonfile "${DIALOG_FORM}")"
     echo $DIALOG_RESULT
     exit
@@ -357,8 +341,6 @@ fi
 
 # A placeholder for a function call to check if the provided file is indeed an MKV file. This is an important validation step to ensure the script operates on valid input.
 #todo _check_if_mkv "${INPUT_FILE}"
-
-INPUT_FILE_NAME="$(basename "${INPUT_FILE}")" # Extracts the file name from the MKV file path.
 
 # Creates a temporary text file to hold the tags and a temporary XML file for drafting the MKV metadata. The tag template will be used for user input, while the XML draft will be used for embedding metadata into the MKV file.
 

--- a/mkvnote
+++ b/mkvnote
@@ -449,7 +449,7 @@ cat << EOF > "${DIALOG_FORM}"
       </vbox>
 </window>
 EOF
-echo "${DIALOG_FORM}" > /tmp/hi ; mate /tmp/hi
+
 DIALOG_RESULT="$(export MAIN_DIALOG="$(cat "${DIALOG_FORM}")" ; gtkdialog --center --program MAIN_DIALOG)"
 echo "${DIALOG_RESULT}"
 EXIT_STATUS="$(echo "${DIALOG_RESULT}" | grep "^EXIT=" | cut -d= -f2- | sed 's/^"//g;s/"$//g')"


### PR DESCRIPTION
With this PR, it's now possible to read/write multi-line metadata.
I'd like some comments on the GUI though. Currently multiline data can be pasted into the GUI and can be saved and loaded into the mkv file. When data is read from the file, there will be a multi-line entry box. So it looks like this 
<img width="1212" alt="image" src="https://github.com/user-attachments/assets/9fbdabf3-59c6-4d7b-af42-4426e6e9e9e4">

Should I keep it like this or should the metadata of the profile be defined to promote a multiline entry box vs a single line one.